### PR TITLE
Format errors in triple extraction caused by the loose definition of relations field

### DIFF
--- a/src/kg_gen/steps/_2_get_relations.py
+++ b/src/kg_gen/steps/_2_get_relations.py
@@ -7,7 +7,14 @@ class TextRelations(dspy.Signature):
   
   source_text: str = dspy.InputField()
   entities: list[str] = dspy.InputField()
-  relations: list[tuple[str, str, str]] = dspy.OutputField(desc="List of subject-predicate-object tuples where subject and object are exact matches to items in entities list. BE THOROUGH")
+  relations: list[tuple[str, str, str]] = dspy.OutputField(
+    desc="""List of subject-predicate-object tuples that must follow these rules:
+    1. Both subject and object MUST be EXACT MATCHES from the provided entities list
+    2. No modifications or abbreviations of entity names are allowed
+    3. Predicate should clearly describe the relationship between entities
+    4. Extract ALL valid relationships mentioned in the text
+    5. Each tuple must be in the format (subject, predicate, object) where subject and object are strings from entities list"""
+  )
 
 class ConversationRelations(dspy.Signature):
   """Extract subject-predicate-object triples from the conversation, including:
@@ -20,7 +27,14 @@ class ConversationRelations(dspy.Signature):
   
   source_text: str = dspy.InputField()
   entities: list[str] = dspy.InputField()
-  relations: list[tuple[str, str, str]] = dspy.OutputField(desc="List of subject-predicate-object tuples where subject and object are exact matches to items in entities list. BE THOROUGH")
+  relations: list[tuple[str, str, str]] = dspy.OutputField(
+    desc="""List of subject-predicate-object tuples that must follow these rules:
+    1. Both subject and object MUST be EXACT MATCHES from the provided entities list
+    2. No modifications or abbreviations of entity names are allowed
+    3. Predicate should clearly describe the relationship between entities
+    4. Extract ALL valid relationships mentioned in the text
+    5. Each tuple must be in the format (subject, predicate, object) where subject and object are strings from entities list"""
+  )
 
 def get_relations(dspy: dspy.dspy, input_data: str, entities: list[str], is_conversation: bool = False) -> List[str]:
   if is_conversation:


### PR DESCRIPTION
When extracting from a Markdown document of a paper in the biological field that was uploaded, the problem encountered was that the extracted relationships did not conform to the format of list[tuple(str, str, str)].

![image](https://github.com/user-attachments/assets/5e325cf9-a31b-4cb3-9a4a-17d14d1d59ae)

[s00726-014-1768-1.md](https://github.com/user-attachments/files/18920405/s00726-014-1768-1.md)
