### PR TITLE
fix: handle None fixed_relations in fallback relation extraction

### DIFF
--- a/src/kg_gen/steps/_2_get_relations.py
+++ b/src/kg_gen/steps/_2_get_relations.py
@@ -281,7 +281,7 @@ def get_relations(
         )
 
         good_relations = []
-        for rel in fix_res.fixed_relations:
+        for rel in (fix_res.fixed_relations or []):
             if rel.subject in entities and rel.object in entities:
                 good_relations.append(rel)
         return [(r.subject, r.predicate, r.object) for r in good_relations]


### PR DESCRIPTION
Some LLMs (e.g., Gemini) occasionally return null for the fixed_relations output field in FixedRelations DSPy signature, causing TypeError: 'NoneType' object is not iterable.

Use `or []` to safely iterate over potentially None value.