### PR TITLE
fix: update semhash API — rename duplicates to filtered

### DIFF
--- a/src/kg_gen/utils/deduplicate.py
+++ b/src/kg_gen/utils/deduplicate.py
@@ -69,11 +69,11 @@ class DeduplicateList:
         deduplication_result = semhash.self_deduplicate(threshold=self.threshold)
 
         self.deduplicated_items = len(deduplication_result.selected)
-        self.duplicate_items = len(deduplication_result.duplicates)
+        self.duplicate_items = len(deduplication_result.filtered)
         self.reduction = (self.duplicate_items / self.total_items) * 100
 
         # Map back to original strings
-        duplicates = deduplication_result.duplicates
+        duplicates = deduplication_result.filtered
         for duplicate in duplicates:
             original = duplicate.record
             # Check if duplicates list is not empty before accessing


### PR DESCRIPTION
## Problem

SemHash's `DeduplicationResult` renamed the `duplicates` attribute to `filtered` in recent versions. This causes an `AttributeError` when running semhash-based deduplication:

```
AttributeError: 'DeduplicationResult' object has no attribute 'duplicates'
```

Reproducible with current `pyproject.toml` deps (`semhash>=0.3.2`) on a fresh install.

## Fix

Replace the two references to `deduplication_result.duplicates` with `deduplication_result.filtered` in `src/kg_gen/utils/deduplicate.py`. The inner `DuplicateRecord` structure (`.record`, `.duplicates`) is unchanged — only the top-level attribute on `DeduplicationResult` was renamed.

## Verified

Tested with `DeduplicateList` and `run_semhash_deduplication` — deduplication works correctly after the fix.